### PR TITLE
Update RobustCovariance for scikit-learn 1.6–1.7 compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ max-line-length = 100
 
 [tool.poetry.dependencies]
 python = "^3.10"
-scikit-learn = ">=1.3,<1.7"
+scikit-learn = ">=1.3"
 matplotlib = "^3.8.2"
 scipy = "^1.11.4"
 tqdm = "^4.66.1"

--- a/robpy/covariance/base.py
+++ b/robpy/covariance/base.py
@@ -9,6 +9,20 @@ from sklearn.covariance import EmpiricalCovariance
 from sklearn.exceptions import NotFittedError
 from robpy.utils.distance import mahalanobis_distance
 
+try:
+    from sklearn.utils.validation import validate_data
+    _HAS_PUBLIC_VALIDATE_DATA = True
+except ImportError:
+    _HAS_PUBLIC_VALIDATE_DATA = False
+
+def _safe_validate_data(estimator, X, **kwargs):
+    """Version-safe data validation wrapper."""
+    if _HAS_PUBLIC_VALIDATE_DATA:
+        return validate_data(estimator, X, **kwargs)
+    else:
+        if "ensure_all_finite" in kwargs:
+            kwargs["force_all_finite"] = kwargs.pop("ensure_all_finite")
+        return estimator._validate_data(X, **kwargs)
 
 class RobustCovariance(EmpiricalCovariance):
     def __init__(
@@ -49,7 +63,13 @@ class RobustCovariance(EmpiricalCovariance):
         if self.nans_allowed:
             self.n_features_in_ = X.shape[1]
         else:
-            X = self._validate_data(X)  # this sets n_features_in_ also
+            X = _safe_validate_data(
+                self,
+                X,
+                reset=True,
+                ensure_2d=True,
+                ensure_all_finite=not self.nans_allowed,
+            )
 
         if self.assume_centered:
             self.location_ = np.zeros(X.shape[1])


### PR DESCRIPTION
This PR updates the `RobustCovariance` class to use the public `validate_data` API introduced in scikit-learn 1.6, with a backward-compatible fallback for older versions.  Fixes #16.

- Replaces `_validate_data` with `validate_data(self, X, …)`
- Adds version-safe shim for 1.5–1.7 support
- All tests pass under both scikit-learn 1.6.1 and 1.7.2

- [x] `pytest` passes with both versions.
- [x] No functional regressions observed.